### PR TITLE
Improve extract feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,35 @@ gdrive download --last --extract
 
 **NOTE**
 
-Important note: The ***extract*** function needs some extra programs to execute. By default, we pré-defined some of this programs and options. This is thefined in the ***extractor.py*** file and can be changed directly there, if you want it. We wish to improve and give users the possibility to choose which program they want to use to extract a file.
+The ***extract*** function needs some extra programs to execute. We tried to implement a mechanism that will try to guess the extension of the file you're downloading and use the program you define to extract it. So, first time you try to download a file of a certain type, when it's time to extract the file, our program will ask you which program you want to choose. After that, if you download a file with this same extension, it will extract it automatically (if you added the ***--extract*** option).
+
+This configurations are located with your other files that we need in the *.gdrive* in your *HOME* directory. The file is called ***data_config.json***
+
+Sample
+```json
+{
+  "configs": [
+    {
+      "ext": "application/x-tar",
+      "encoding": "gzip",
+      "prog": "tar",
+      "attrs": "xzvf"
+    },
+    {
+      "ext": null,
+      "encoding": "gzip",
+      "prog": "gunzip",
+      "attrs": null
+    },
+    {
+      "ext": "application/x-tar",
+      "encoding": null,
+      "prog": "tar",
+      "attrs": "xvf"
+    }
+  ]
+}
+```
 
 #### 3. List
 ```sh

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+from os.path import expanduser, join
+
+HOME = expanduser("~")
+GDRIVE_PATH = join(HOME, '.gdrive')
+CREDENTIALS_PATH = join(GDRIVE_PATH, 'credentials.json')
+TOKEN_PATH = join(GDRIVE_PATH, 'token.pickle')
+EXTRACTOR_CONFIG_FILE = join(GDRIVE_PATH, 'data_config.json')
+

--- a/extractor.py
+++ b/extractor.py
@@ -1,147 +1,188 @@
 #!/usr/bin/env python3
-
 from argparse import ArgumentParser
+from json import JSONDecodeError
+import config
+import json
+import logger
 import mimetypes
 import os
 
-DEBUG = False
+_attrs_str = 'attrs'
+_configs_str = 'configs'
+_encoding_str = 'encoding'
+_ext_str = 'ext'
+_result_str = 'result'
+_message_str = 'message'
+_error_str = 'error'
+_error_code_str = 'error_code'
+_prog_str = 'prog'
 
-class Program:
-    _tar_type = 'application/x-tar'
-    _gzip_type = 'gzip'
-    _zip_type = 'application/zip'
-    _7z_type = 'application/x-7z-compressed'
 
-    _tar_ext = '.tar'
-    _targz_ext = '.tar.gz'
-    _gzip_ext = '.gz'
-    _zip_ext = '.zip'
-    _7z_ext = '.7z'
+def extract(filename):
+    print("Will try to extract file:", filename)
+    ext, encoding = _guess_type(filename)
+    if not ext and not encoding:
+        print("Could not guess filetype. Cannot extract")
+        return None
+    config_result = _check_extension(ext, encoding)
+    logger.logd('ExtractorConfig:', config_result)
+    if config_result[_error_str]:
+        print("Cannot extract at this moment")
+        return None
 
-    _tar_prog = 'tar'
-    _targz_prog = 'tar'
-    _gzip_prog = 'guzip'
-    _zip_prog = 'unzip'
-    _7z_prog = '7z'
-    
-    _tar_attr = 'xvf'
-    _targz_attr = 'xzvf'
-    _gzip_attr = ''
-    _zip_attr = ''
-    _7z_attr = 'x'
+    result = config_result[_result_str]
+    if not result[_result_str]:
+        # Need to create file
+        logger.logd("create file for configurations")
+        _create_configuration_file()
 
-    exts = {
-            _tar_type: _tar_ext,
-            _gzip_type: _gzip_ext,
-            _zip_type: _zip_ext,
-            _7z_type: _7z_ext,
-    }
+    prog_config = result[_prog_str]
+    if not prog_config:
+        # Add configuration for this extension
+        logger.logd('add config for this extension', ext, encoding)
+        print('We are going to need to add a new config for', filename)
+        prog_config = _configure_new_item(ext, encoding)
+        if not prog_config:
+            print('Could not extract for this type of file at this moment.')
+            logger.logd('User did not enter a new configuration')
+            return
 
-    progs = {
-            _tar_ext: _tar_prog,
-            _targz_ext: _targz_prog,
-            _gzip_ext: _gzip_prog,
-            _zip_ext: _zip_prog,
-            _7z_ext: _7z_prog,
-    }
+    logger.logd('Found config:', prog_config)
 
-    attrs = {
-            _tar_ext: _tar_attr,
-            _targz_ext: _targz_attr,
-            _gzip_ext: _gzip_attr,
-            _zip_ext: _zip_attr,
-            _7z_ext: _7z_attr,
-    }
+    try:
+        prog_command = prog_config[_prog_str]
+    except KeyError:
+        print('Could not extract')
+        return None
 
-    def get_full_command(self, prog, ext, filename):
-        if not prog:
-            print("Could not define which program we should use to extract your file");
-            return None
+    prog = _Program(prog_command)
+    prog.execute(prog_config[_attrs_str], filename)
+
+
+def _error_builder(error_code, error_message):
+    return {_error_code_str: error_code, _message_str: error_message}
+
+
+def _result_builder(result_status, prog_for_ext):
+    return {_result_str: result_status, _prog_str: prog_for_ext}
+
+
+def _response_builder(error_obj, result_obj, message):
+    return {_error_str: error_obj, _result_str: result_obj, _message_str: message}
+
+
+def _check_extension(ext, encoding):
+    logger.logd(f'check_extension, (ext, encoding) = ({ext},{encoding})')
+    if not ext and not encoding:
+        msg = 'Invalid extension and encoding'
+        logger.logd(msg)
+        err = _error_builder(1, msg)
+        return _response_builder(err, None, err[_message_str])
+
+    if not os.path.isfile(config.EXTRACTOR_CONFIG_FILE):
+        logger.logd('No configuration file', config.EXTRACTOR_CONFIG_FILE)
+        return _response_builder(None, _result_builder(False, None), 'No configuration file')
+
+    with open(config.EXTRACTOR_CONFIG_FILE, 'r') as f:
+        try:
+            json_data = json.load(f)
+        except JSONDecodeError:
+            logger.logd('Could not load configurations')
+            err = _error_builder(2, 'File is not json')
+            return _response_builder(err, None, err[_message_str])
+
+    logger.logd(f'file content: {json_data}')
+
+    try:
+        configs = json_data[_configs_str]
+    except KeyError:
+        msg = 'File with different json object than expected' 
+        logger.logd(msg)
+        err = _error_builder(3, msg)
+        return _response_builder(err, None, msg)
+
+    if not configs:
+        msg = 'No configuration for extension' + ext
+        return _response_builder(None, _result_builder(False, None), msg)
+
+    for cfg in configs:
+        ext_cfg = cfg[_ext_str]
+        encoding_cfg = cfg[_encoding_str]
         if not ext:
-            print("Could not define the extension of your file");
+            if encoding == encoding_cfg and not ext_cfg:
+                return _response_builder(None, _result_builder(True, cfg), 'Found configuration')
+            continue
+
+        if ext == ext_cfg and encoding == encoding_cfg:
+            return _response_builder(None, _result_builder(True, cfg), 'Found configuration')
+
+    return _response_builder(None, _result_builder(True, None), 'Did not find a configuration')
+
+
+def _create_configuration_file():
+    data = {_configs_str: []}
+
+    with open(config.EXTRACTOR_CONFIG_FILE, 'w') as outfile:
+        json.dump(data, outfile, indent=2)
+
+
+def _add_config(extension, encoding, prog, attrs):
+    logger.logd('add_config called:', extension, encoding, prog, attrs)
+
+    with open(config.EXTRACTOR_CONFIG_FILE, 'r') as f:
+        try:
+            json_data = json.load(f)
+        except JSONDecodeError:
+            logger.logd('add_config exception')
+            print('Could not add a new configuration to your file')
             return None
+
+    item = {
+        _ext_str: extension,
+        _encoding_str: encoding,
+        _prog_str: prog,
+        _attrs_str: attrs
+    }
+
+    json_data[_configs_str].append(item)
+
+    with open(config.EXTRACTOR_CONFIG_FILE, 'w') as outfile:
+        json.dump(json_data, outfile, indent=2)
+    return item
+
+
+def _configure_new_item(extension, encoding):
+    prog = input('What\'s the program? (No options) ') or None
+    opts = input('Options? ') or None
+    return _add_config(extension, encoding, prog, opts) if prog else None
+
+
+def _guess_type(filename):
+    return mimetypes.guess_type(filename, False)
+
+
+class _Program:
+
+    def __init__(self, prog):
+        self._prog = prog
+
+    def execute(self, attrs, filename):
         if not filename:
             print("Could not get the name of your file")
             return None
-        return prog + ' ' + self.attrs[ext] + ' ' + filename
+        if not attrs:
+            attrs = ''
+        full_command = self._prog + ' ' + attrs + ' ' + filename
+        logger.logd('execute:', full_command)
+        os.system(full_command)
 
-    def get_proper_ext(self, extension):
-        if not extension:
-            return None
-        if len(extension) > 2:
-            print("We don't support this extension.")
-            return None
-        if extension[0] is None:
-            if extension[1] is None:
-                print("We don't support this extension.")
-                return None
-            return self.exts[extension[1]]
-        else:
-            if extension[1] is None:
-                return self.exts[extension[0]]
-            _ext0 = self.exts[extension[0]]
-            _ext1 = self.exts[extension[1]]
-            appended_ext = _ext0 + _ext1
-            return appended_ext
 
-    def get_prog(self, _ext):
-        if not _ext:
-            print("Invalid extension")
-            return None
-        _prog = self.progs[_ext]
-        if not _prog:
-            print("We don't support this file type")
-            return None
-        return _prog
-
-class Extractor:
-
-    def get_prog(self, extensions):
-        if not extensions:
-            return None
-
-    def build_command(self, program, filename):
-        if not program:
-            return None
-        if not filename:
-            return None
-
-    def guess_type(self, filename):
-        ext = mimetypes.guess_type(filename, False)
-        if not ext:
-            return None
-        if DEBUG:
-            print(ext)
-        return ext
-
-    def extract(self, filename):
-        print("Will try to extract file:", filename)
-        ext = self.guess_type(filename)
-        if not ext:
-            print("Could not guess filetype. Cannot extract")
-            return None
-        prog = Program()
-        _ext = prog.get_proper_ext(ext)
-        if not _ext:
-            print("Cannot extract at this moment")
-            return None
-
-        _prog = prog.get_prog(_ext)
-
-        _command = prog.get_full_command(_prog, _ext, filename)
-        if DEBUG:
-            print(_command)
-        if not _command:
-            return
-
-        os.system(_command)
-
-def main():
+def _test():
     parser = ArgumentParser()
-    parser.add_argument("filename")
+    parser.add_argument('filename')
     args = parser.parse_args()
-    Extractor().extract(args.filename)
+    extract(args.filename)
+
 
 if __name__ == '__main__':
-    main()
-
+    _test()

--- a/gdrive.py
+++ b/gdrive.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
 """A script to interact with your Google Drive files using the terminal"""
-
 import os
 import io
 import pickle
 import mimetypes
 import threading
 import time
+import config
+import extractor
 from argparse import ArgumentParser
-from os.path import expanduser, join
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
@@ -17,14 +17,9 @@ from googleapiclient.http import MediaIoBaseDownload
 from googleapiclient.http import MediaFileUpload
 from googleapiclient.errors import HttpError
 
-from extractor import Extractor
 
 class GoogleCredentials():
     """Handles the local Credentials file for the Google Drive API"""
-    HOME = expanduser("~")
-    GDRIVE_PATH = join(HOME, '.gdrive')
-    CREDENTIALS_PATH = join(GDRIVE_PATH, 'credentials.json')
-    TOKEN_PATH = join(GDRIVE_PATH, 'token.pickle')
     SCOPES = [
         'https://www.googleapis.com/auth/drive',
         'https://www.googleapis.com/auth/drive.metadata'
@@ -48,8 +43,8 @@ class GoogleCredentials():
 
     def load_credentials(self):
         self.__creds = None
-        if os.path.exists(self.TOKEN_PATH):
-            with open(self.TOKEN_PATH, 'rb') as token:
+        if os.path.exists(config.TOKEN_PATH):
+            with open(config.TOKEN_PATH, 'rb') as token:
                 self.__creds = pickle.load(token)
 
     def is_credentials_valid(self):
@@ -59,15 +54,15 @@ class GoogleCredentials():
         return self.__creds.expired and self.__creds.refresh_token
 
     def create_credentials(self):
-        if os.path.exists(self.CREDENTIALS_PATH):
-            flow = InstalledAppFlow.from_client_secrets_file(self.CREDENTIALS_PATH, self.SCOPES)
+        if os.path.exists(config.CREDENTIALS_PATH):
+            flow = InstalledAppFlow.from_client_secrets_file(config.CREDENTIALS_PATH, self.SCOPES)
             self.__creds = flow.run_local_server(port=0)
         else:
-            print('Credentials not found at %s' % self.CREDENTIALS_PATH)
+            print('Credentials not found at %s' % config.CREDENTIALS_PATH)
             exit()
 
     def save_credentials(self):
-        with open(self.TOKEN_PATH, 'wb') as token:
+        with open(config.TOKEN_PATH, 'wb') as token:
             pickle.dump(self.__creds, token)
 
 
@@ -271,9 +266,8 @@ class Download(Command):
         if not downloaded_file:
             return None
         if extract:
-            Extractor().extract(file_name)
+            extractor.extract(file_name)
         return downloaded_file
-
 
     def download(self, file_id, file_name):
         try:

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,5 @@
+DEBUG = False
+
+def logd(*args):
+    if DEBUG:
+        print(args)


### PR DESCRIPTION
We were forcing the user to use a selected group of programs to extract
the downloaded files.

Now we added a functionality where users are asked which program they
want to use for that type of file. Once it registers, we save this
option and if we have this file extension again, we will use the
previous configuration and extract it automatically (if users used the
--extract option).