### PR TITLE
Fix install requirements for pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
-
 contextvars; python_version == '3.6'
 dataclasses; python_version == '3.6'

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,12 @@ import setuptools
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+with open("requirements.txt", "r", encoding="utf-8") as fh:
+    install_requires = fh.read().splitlines()
+
 setuptools.setup(
     name='ggdrive',
-    version='0.1.3',
+    version='0.1.4',
     scripts=['gdrive'],
     author="DiscordTime",
     description="A command-line tool for operating on Google Drive directly from the terminal.",
@@ -14,6 +17,7 @@ setuptools.setup(
     url="https://github.com/DiscordTime/ggdrive",
     packages=setuptools.find_packages(),
     python_requires=">=3.6",
+    install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
setup.py requires install_requires parameter for automatic handling of dependencies.

Requirements will be read from the requirements.txt file.